### PR TITLE
Fix improper length for buffer passed to VANC engine.

### DIFF
--- a/tools/scte104to35.c
+++ b/tools/scte104to35.c
@@ -104,7 +104,7 @@ static int parse(struct vanc_context_s *ctx, uint8_t *sec, int byteCount)
 		arr[i] = sec[i * 2] << 8 | sec[i * 2 + 1];
 	}
 
-	int ret = vanc_packet_parse(ctx, 13, arr, byteCount / 2 * (sizeof(unsigned short)));
+	int ret = vanc_packet_parse(ctx, 13, arr, byteCount / sizeof(unsigned short));
 	free(arr);
 
 	return ret;


### PR DESCRIPTION
The VANC engine expects the number of uint16_t structs, not the
number of bytes.  This was tripping errors in Valgrind when we
blew past the end of the buffer.