### PR TITLE
Accommodate function renaming in libklvanc

### DIFF
--- a/src/libklscte35/scte35.h
+++ b/src/libklscte35/scte35.h
@@ -234,7 +234,7 @@ struct splice_entries
 	uint32_t splice_size[MAX_SPLICES];
 };
 
-int scte35_generate_from_scte104(struct packet_scte_104_s *pkt, struct splice_entries *results,
+int scte35_generate_from_scte104(struct klvanc_packet_scte_104_s *pkt, struct splice_entries *results,
 				 uint64_t pts);
 
 /**

--- a/src/scte35-from104.c
+++ b/src/scte35-from104.c
@@ -34,12 +34,12 @@
 #include "libklscte35/scte35.h"
 #include "klbitstream_readwriter.h"
 
-static int scte35_generate_spliceinsert(struct packet_scte_104_s *pkt, int momOpNumber,
+static int scte35_generate_spliceinsert(struct klvanc_packet_scte_104_s *pkt, int momOpNumber,
 					struct scte35_splice_info_section_s *splices[],
 					int *outSpliceNum, uint64_t pts)
 {
-	struct multiple_operation_message *m = &pkt->mo_msg;
-	struct multiple_operation_message_operation *op = &m->ops[momOpNumber];
+	struct klvanc_multiple_operation_message *m = &pkt->mo_msg;
+	struct klvanc_multiple_operation_message_operation *op = &m->ops[momOpNumber];
 	struct scte35_splice_info_section_s *si;
 
 	si = scte35_splice_info_section_alloc(SCTE35_COMMAND_TYPE__SPLICE_INSERT);
@@ -105,7 +105,7 @@ static int scte35_generate_spliceinsert(struct packet_scte_104_s *pkt, int momOp
 	return 0;
 }
 
-static int scte35_generate_splicenull(struct packet_scte_104_s *pkt, int momOpNumber,
+static int scte35_generate_splicenull(struct klvanc_packet_scte_104_s *pkt, int momOpNumber,
 				      struct scte35_splice_info_section_s *splices[], int *outSpliceNum)
 {
 	struct scte35_splice_info_section_s *si;
@@ -119,12 +119,12 @@ static int scte35_generate_splicenull(struct packet_scte_104_s *pkt, int momOpNu
 	return 0;
 }
 
-static int scte35_generate_timesignal(struct packet_scte_104_s *pkt, int momOpNumber,
+static int scte35_generate_timesignal(struct klvanc_packet_scte_104_s *pkt, int momOpNumber,
 				      struct scte35_splice_info_section_s *splices[], int *outSpliceNum,
 				      uint64_t pts)
 {
-	struct multiple_operation_message *m = &pkt->mo_msg;
-	struct multiple_operation_message_operation *op = &m->ops[momOpNumber];
+	struct klvanc_multiple_operation_message *m = &pkt->mo_msg;
+	struct klvanc_multiple_operation_message_operation *op = &m->ops[momOpNumber];
 	struct scte35_splice_info_section_s *si;
 
 	si = scte35_splice_info_section_alloc(SCTE35_COMMAND_TYPE__TIME_SIGNAL);
@@ -142,12 +142,12 @@ static int scte35_generate_timesignal(struct packet_scte_104_s *pkt, int momOpNu
 	return 0;
 }
 
-static int scte35_generate_proprietary(struct packet_scte_104_s *pkt, int momOpNumber,
+static int scte35_generate_proprietary(struct klvanc_packet_scte_104_s *pkt, int momOpNumber,
 				       struct scte35_splice_info_section_s *splices[],
 				       int *outSpliceNum)
 {
-	struct multiple_operation_message *m = &pkt->mo_msg;
-	struct multiple_operation_message_operation *op = &m->ops[momOpNumber];
+	struct klvanc_multiple_operation_message *m = &pkt->mo_msg;
+	struct klvanc_multiple_operation_message_operation *op = &m->ops[momOpNumber];
 	struct scte35_splice_info_section_s *si;
 
 
@@ -166,12 +166,12 @@ static int scte35_generate_proprietary(struct packet_scte_104_s *pkt, int momOpN
 	return 0;
 }
 
-static int scte35_append_104_descriptor(struct packet_scte_104_s *pkt, int momOpNumber,
+static int scte35_append_104_descriptor(struct klvanc_packet_scte_104_s *pkt, int momOpNumber,
 					struct scte35_splice_info_section_s *splices[], int *outSpliceNum)
 {
-	struct multiple_operation_message *m = &pkt->mo_msg;
-	struct multiple_operation_message_operation *op = &m->ops[momOpNumber];
-	struct insert_descriptor_request_data *des = &op->descriptor_data;
+	struct klvanc_multiple_operation_message *m = &pkt->mo_msg;
+	struct klvanc_multiple_operation_message_operation *op = &m->ops[momOpNumber];
+	struct klvanc_insert_descriptor_request_data *des = &op->descriptor_data;
 	struct scte35_splice_info_section_s *si;
 	struct splice_descriptor *sd;
 	uint8_t len;
@@ -200,11 +200,11 @@ static int scte35_append_104_descriptor(struct packet_scte_104_s *pkt, int momOp
 	return 0;
 }
 
-static int scte35_append_104_dtmf(struct packet_scte_104_s *pkt, int momOpNumber,
+static int scte35_append_104_dtmf(struct klvanc_packet_scte_104_s *pkt, int momOpNumber,
 				  struct scte35_splice_info_section_s *splices[], int *outSpliceNum)
 {
-	struct multiple_operation_message *m = &pkt->mo_msg;
-	struct multiple_operation_message_operation *op = &m->ops[momOpNumber];
+	struct klvanc_multiple_operation_message *m = &pkt->mo_msg;
+	struct klvanc_multiple_operation_message_operation *op = &m->ops[momOpNumber];
 	struct scte35_splice_info_section_s *si;
 	struct splice_descriptor *sd;
 	int ret, i;
@@ -242,11 +242,11 @@ static int scte35_append_104_dtmf(struct packet_scte_104_s *pkt, int momOpNumber
 	return 0;
 }
 
-static int scte35_append_104_avail(struct packet_scte_104_s *pkt, int momOpNumber,
+static int scte35_append_104_avail(struct klvanc_packet_scte_104_s *pkt, int momOpNumber,
 				   struct scte35_splice_info_section_s *splices[], int *outSpliceNum)
 {
-	struct multiple_operation_message *m = &pkt->mo_msg;
-	struct multiple_operation_message_operation *op = &m->ops[momOpNumber];
+	struct klvanc_multiple_operation_message *m = &pkt->mo_msg;
+	struct klvanc_multiple_operation_message_operation *op = &m->ops[momOpNumber];
 	struct scte35_splice_info_section_s *si;
 	struct splice_descriptor *sd;
 	int ret, i;
@@ -287,13 +287,13 @@ static int scte35_append_104_avail(struct packet_scte_104_s *pkt, int momOpNumbe
 	return 0;
 }
 
-static int scte35_append_104_segmentation(struct packet_scte_104_s *pkt, int momOpNumber,
+static int scte35_append_104_segmentation(struct klvanc_packet_scte_104_s *pkt, int momOpNumber,
 					  struct scte35_splice_info_section_s *splices[],
 					  int *outSpliceNum)
 {
-	struct multiple_operation_message *m = &pkt->mo_msg;
-	struct multiple_operation_message_operation *op = &m->ops[momOpNumber];
-	struct segmentation_descriptor_request_data *seg = &op->segmentation_data;
+	struct klvanc_multiple_operation_message *m = &pkt->mo_msg;
+	struct klvanc_multiple_operation_message_operation *op = &m->ops[momOpNumber];
+	struct klvanc_segmentation_descriptor_request_data *seg = &op->segmentation_data;
 	struct scte35_splice_info_section_s *si;
 	struct splice_descriptor *sd;
 	int ret, i;
@@ -348,13 +348,13 @@ static int scte35_append_104_segmentation(struct packet_scte_104_s *pkt, int mom
 	return 0;
 }
 
-static int scte35_append_104_tier(struct packet_scte_104_s *pkt, int momOpNumber,
+static int scte35_append_104_tier(struct klvanc_packet_scte_104_s *pkt, int momOpNumber,
 				  struct scte35_splice_info_section_s *splices[],
 				  int *outSpliceNum)
 {
-	struct multiple_operation_message *m = &pkt->mo_msg;
-	struct multiple_operation_message_operation *op = &m->ops[momOpNumber];
-	struct tier_data *tier = &op->tier_data;
+	struct klvanc_multiple_operation_message *m = &pkt->mo_msg;
+	struct klvanc_multiple_operation_message_operation *op = &m->ops[momOpNumber];
+	struct klvanc_tier_data *tier = &op->tier_data;
 	struct scte35_splice_info_section_s *si;
 
 	/* The command to set the tier could apply to any splice_info message */
@@ -370,12 +370,12 @@ static int scte35_append_104_tier(struct packet_scte_104_s *pkt, int momOpNumber
 	return 0;
 }
 
-static int scte35_append_104_time(struct packet_scte_104_s *pkt, int momOpNumber,
+static int scte35_append_104_time(struct klvanc_packet_scte_104_s *pkt, int momOpNumber,
 				  struct scte35_splice_info_section_s *splices[], int *outSpliceNum)
 {
-	struct multiple_operation_message *m = &pkt->mo_msg;
-	struct multiple_operation_message_operation *op = &m->ops[momOpNumber];
-	struct time_descriptor_data *des = &op->time_data;
+	struct klvanc_multiple_operation_message *m = &pkt->mo_msg;
+	struct klvanc_multiple_operation_message_operation *op = &m->ops[momOpNumber];
+	struct klvanc_time_descriptor_data *des = &op->time_data;
 	struct scte35_splice_info_section_s *si;
 	struct splice_descriptor *sd;
 	int i, ret;
@@ -411,11 +411,11 @@ static int scte35_append_104_time(struct packet_scte_104_s *pkt, int momOpNumber
 	return 0;
 }
 
-int scte35_generate_from_scte104(struct packet_scte_104_s *pkt, struct splice_entries *results,
+int scte35_generate_from_scte104(struct klvanc_packet_scte_104_s *pkt, struct splice_entries *results,
 				 uint64_t pts)
 {
 	/* See SCTE-104 Sec 8.3.1.1 Semantics of fields in splice_request_data() */
-	struct multiple_operation_message *m = &pkt->mo_msg;
+	struct klvanc_multiple_operation_message *m = &pkt->mo_msg;
 	struct scte35_splice_info_section_s *splices[MAX_SPLICES];
 	int num_splices = 0;
 
@@ -427,7 +427,7 @@ int scte35_generate_from_scte104(struct packet_scte_104_s *pkt, struct splice_en
 
 	/* Iterate over each of the operations in the Multiple Operation Message */
 	for (int i = 0; i < m->num_ops; i++) {
-		struct multiple_operation_message_operation *o = &m->ops[i];
+		struct klvanc_multiple_operation_message_operation *o = &m->ops[i];
 
 		switch(o->opID) {
 		case MO_SPLICE_REQUEST_DATA:

--- a/src/scte35-to104.c
+++ b/src/scte35-to104.c
@@ -31,9 +31,9 @@
 #define SPLICE_INSERT_CANCEL          0x05
 
 static int scte104_generate_splice_request(const struct scte35_splice_insert_s *si, uint64_t pts,
-					   struct packet_scte_104_s *pkt)
+					   struct klvanc_packet_scte_104_s *pkt)
 {
-	struct multiple_operation_message_operation *op;
+	struct klvanc_multiple_operation_message_operation *op;
 	uint8_t splice_insert_type;
 	uint32_t preroll = 0;
 	uint64_t duration = 0;
@@ -85,9 +85,9 @@ static int scte104_generate_splice_request(const struct scte35_splice_insert_s *
 }
 
 static int scte104_generate_splice_null(const struct scte35_splice_null_s *si, uint64_t pts,
-					struct packet_scte_104_s *pkt)
+					struct klvanc_packet_scte_104_s *pkt)
 {
-	struct multiple_operation_message_operation *op;
+	struct klvanc_multiple_operation_message_operation *op;
 	int ret;
 
 	ret =  klvanc_SCTE_104_Add_MOM_Op(pkt, MO_SPLICE_NULL_REQUEST_DATA, &op);
@@ -100,9 +100,9 @@ static int scte104_generate_splice_null(const struct scte35_splice_null_s *si, u
 }
 
 static int scte104_generate_time_signal(const struct scte35_splice_time_s *si, uint64_t pts,
-					struct packet_scte_104_s *pkt)
+					struct klvanc_packet_scte_104_s *pkt)
 {
-	struct multiple_operation_message_operation *op;
+	struct klvanc_multiple_operation_message_operation *op;
 	int ret;
 
 	ret =  klvanc_SCTE_104_Add_MOM_Op(pkt, MO_TIME_SIGNAL_REQUEST_DATA, &op);
@@ -120,9 +120,9 @@ static int scte104_generate_time_signal(const struct scte35_splice_time_s *si, u
 }
 
 static int scte104_generate_proprietary(const struct scte35_splice_private_s *si, uint64_t pts,
-					struct packet_scte_104_s *pkt)
+					struct klvanc_packet_scte_104_s *pkt)
 {
-	struct multiple_operation_message_operation *op;
+	struct klvanc_multiple_operation_message_operation *op;
 	int ret;
 
 	ret =  klvanc_SCTE_104_Add_MOM_Op(pkt, MO_PROPRIETARY_COMMAND_REQUEST_DATA, &op);
@@ -138,9 +138,9 @@ static int scte104_generate_proprietary(const struct scte35_splice_private_s *si
 	return 0;
 }
 
-static int scte35_append_descriptor(struct splice_descriptor *sd, struct packet_scte_104_s *pkt)
+static int scte35_append_descriptor(struct splice_descriptor *sd, struct klvanc_packet_scte_104_s *pkt)
 {
-	struct multiple_operation_message_operation *op;
+	struct klvanc_multiple_operation_message_operation *op;
 	int ret;
 
 	ret = klvanc_SCTE_104_Add_MOM_Op(pkt, MO_INSERT_DESCRIPTOR_REQUEST_DATA, &op);
@@ -156,9 +156,9 @@ static int scte35_append_descriptor(struct splice_descriptor *sd, struct packet_
 	return 0;
 }
 
-static int scte35_append_dtmf(struct splice_descriptor *sd, struct packet_scte_104_s *pkt)
+static int scte35_append_dtmf(struct splice_descriptor *sd, struct klvanc_packet_scte_104_s *pkt)
 {
-	struct multiple_operation_message_operation *op;
+	struct klvanc_multiple_operation_message_operation *op;
 	int ret;
 
 	ret = klvanc_SCTE_104_Add_MOM_Op(pkt, MO_INSERT_DTMF_REQUEST_DATA, &op);
@@ -176,9 +176,9 @@ static int scte35_append_dtmf(struct splice_descriptor *sd, struct packet_scte_1
 	return 0;
 }
 
-static int scte35_append_avail(struct splice_descriptor *sd, struct packet_scte_104_s *pkt)
+static int scte35_append_avail(struct splice_descriptor *sd, struct klvanc_packet_scte_104_s *pkt)
 {
-	struct multiple_operation_message_operation *op;
+	struct klvanc_multiple_operation_message_operation *op;
 	int ret;
 
 	ret = klvanc_SCTE_104_Add_MOM_Op(pkt, MO_INSERT_AVAIL_DESCRIPTOR_REQUEST_DATA, &op);
@@ -191,10 +191,10 @@ static int scte35_append_avail(struct splice_descriptor *sd, struct packet_scte_
 	return 0;
 }
 
-static int scte35_append_segmentation(struct splice_descriptor *sd, struct packet_scte_104_s *pkt)
+static int scte35_append_segmentation(struct splice_descriptor *sd, struct klvanc_packet_scte_104_s *pkt)
 {
-	struct multiple_operation_message_operation *op;
-	struct segmentation_descriptor_request_data *seg;
+	struct klvanc_multiple_operation_message_operation *op;
+	struct klvanc_segmentation_descriptor_request_data *seg;
 	int ret;
 
 	ret = klvanc_SCTE_104_Add_MOM_Op(pkt, MO_INSERT_SEGMENTATION_REQUEST_DATA, &op);
@@ -221,9 +221,9 @@ static int scte35_append_segmentation(struct splice_descriptor *sd, struct packe
 	return 0;
 }
 
-static int scte35_append_tier(struct scte35_splice_info_section_s *s, struct packet_scte_104_s *pkt)
+static int scte35_append_tier(struct scte35_splice_info_section_s *s, struct klvanc_packet_scte_104_s *pkt)
 {
-	struct multiple_operation_message_operation *op;
+	struct klvanc_multiple_operation_message_operation *op;
 	int ret;
 
 	ret = klvanc_SCTE_104_Add_MOM_Op(pkt, MO_INSERT_TIER_DATA, &op);
@@ -235,10 +235,10 @@ static int scte35_append_tier(struct scte35_splice_info_section_s *s, struct pac
 	return 0;
 }
 
-static int scte35_append_time(struct splice_descriptor *sd, struct packet_scte_104_s *pkt)
+static int scte35_append_time(struct splice_descriptor *sd, struct klvanc_packet_scte_104_s *pkt)
 {
-	struct multiple_operation_message_operation *op;
-	struct time_descriptor_data *t;
+	struct klvanc_multiple_operation_message_operation *op;
+	struct klvanc_time_descriptor_data *t;
 	int ret;
 
 	ret = klvanc_SCTE_104_Add_MOM_Op(pkt, MO_INSERT_TIME_DESCRIPTOR, &op);
@@ -255,11 +255,11 @@ static int scte35_append_time(struct splice_descriptor *sd, struct packet_scte_1
 
 int scte35_create_scte104_message(struct scte35_splice_info_section_s *s, uint8_t **buf, uint16_t *byteCount, uint64_t pts)
 {
-	struct packet_scte_104_s *pkt;
+	struct klvanc_packet_scte_104_s *pkt;
 	int ret = -1;
 
 	/* Create a Multiple Operation Message SCTE-104 packet */
-	ret = alloc_SCTE_104(0xffff, &pkt);
+	ret = klvanc_alloc_SCTE_104(0xffff, &pkt);
 	if (ret != 0)
 		return ret;
 
@@ -314,6 +314,6 @@ int scte35_create_scte104_message(struct scte35_splice_info_section_s *s, uint8_
 	}
 
 	/* Serialize the Multiple Operation Message out to a VANC array */
-	ret = convert_SCTE_104_to_packetBytes(pkt, buf, byteCount);
+	ret = klvanc_convert_SCTE_104_to_packetBytes(pkt, buf, byteCount);
 	return ret;
 }

--- a/tools/scte104.c
+++ b/tools/scte104.c
@@ -81,7 +81,8 @@ static uint8_t multi_descriptor_test1[] = {
 };
 
 #ifdef DEBUG_RENDER_104
-static int cb_SCTE_104(void *callback_context, struct vanc_context_s *ctx, struct packet_scte_104_s *pkt)
+static int cb_SCTE_104(void *callback_context, struct klvanc_context_s *ctx,
+		       struct klvanc_packet_scte_104_s *pkt)
 {
 	printf("%s:%s()\n", __FILE__, __func__);
 
@@ -92,7 +93,7 @@ static int cb_SCTE_104(void *callback_context, struct vanc_context_s *ctx, struc
 	return 0;
 }
 
-static struct vanc_callbacks_s callbacks =
+static struct klvanc_callbacks_s callbacks =
 {
 	.scte_104		= cb_SCTE_104,
 };
@@ -131,7 +132,7 @@ static int parse(uint8_t *sec, int byteCount)
 			 */
 			uint16_t *vancWords;
 			uint16_t vancWordCount;
-			ret = vanc_sdi_create_payload(0x07, 0x41, buf, byteCount, &vancWords, &vancWordCount, 10);
+			ret = klvanc_sdi_create_payload(0x07, 0x41, buf, byteCount, &vancWords, &vancWordCount, 10);
 			if (ret == 0) {
 				printf("SCTE104 in VANC: ");
 				for (int i = 0; i < vancWordCount; i++)
@@ -140,14 +141,14 @@ static int parse(uint8_t *sec, int byteCount)
 
 #ifdef DEBUG_RENDER_104
 				/* Feed it back into the VANC parser so we can decode it */
-				struct vanc_context_s *ctx;
-				if (vanc_context_create(&ctx) < 0) {
+				struct klvanc_context_s *ctx;
+				if (klvanc_context_create(&ctx) < 0) {
 					fprintf(stderr, "Error initializing library context\n");
 					exit(1);
 				}
 				ctx->verbose = 1;
 				ctx->callbacks = &callbacks;
-				int ret = vanc_packet_parse(ctx, 13, vancWords, vancWordCount);
+				int ret = klvanc_packet_parse(ctx, 13, vancWords, vancWordCount);
 #endif
 
 				free(vancWords); /* Free the allocated resource */

--- a/tools/scte104to35.c
+++ b/tools/scte104to35.c
@@ -57,7 +57,8 @@ unsigned char __0_vancentry[] = {
 	0x02, 0x56, 0x02, 0x4e, 0x01, 0x54, 0x02, 0x00, 0x02, 0x06
 };
 
-static int cb_SCTE_104(void *callback_context, struct vanc_context_s *ctx, struct packet_scte_104_s *pkt)
+static int cb_SCTE_104(void *callback_context, struct klvanc_context_s *ctx,
+		       struct klvanc_packet_scte_104_s *pkt)
 {
 	struct splice_entries results;
 	int ret;
@@ -66,7 +67,7 @@ static int cb_SCTE_104(void *callback_context, struct vanc_context_s *ctx, struc
 
 	/* Have the library display some debug */
 	printf("Asking libklvanc to dump a struct\n");
-	dump_SCTE_104(ctx, pkt);
+	klvanc_dump_SCTE_104(ctx, pkt);
 
 	/* Let's encode it to SCTE-35 */
 	ret = scte35_generate_from_scte104(pkt, &results, TEST_PTS_TIME);
@@ -92,12 +93,12 @@ static int cb_SCTE_104(void *callback_context, struct vanc_context_s *ctx, struc
 	return 0;
 }
 
-static struct vanc_callbacks_s callbacks = 
+static struct klvanc_callbacks_s callbacks =
 {
 	.scte_104		= cb_SCTE_104,
 };
 
-static int parse(struct vanc_context_s *ctx, uint8_t *sec, int byteCount)
+static int parse(struct klvanc_context_s *ctx, uint8_t *sec, int byteCount)
 {
 	printf("\nParsing a new SCTE104 VANC packet......\n");
 	uint16_t *arr = malloc(byteCount / 2 * sizeof(uint16_t));
@@ -108,7 +109,7 @@ static int parse(struct vanc_context_s *ctx, uint8_t *sec, int byteCount)
 		arr[i] = sec[i * 2] << 8 | sec[i * 2 + 1];
 	}
 
-	int ret = vanc_packet_parse(ctx, 13, arr, byteCount / sizeof(unsigned short));
+	int ret = klvanc_packet_parse(ctx, 13, arr, byteCount / sizeof(unsigned short));
 	free(arr);
 
 	return ret;
@@ -116,9 +117,9 @@ static int parse(struct vanc_context_s *ctx, uint8_t *sec, int byteCount)
 
 int scte104to35_main(int argc, char *argv[])
 {
-	struct vanc_context_s *ctx;
+	struct klvanc_context_s *ctx;
 
-	if (vanc_context_create(&ctx) < 0) {
+	if (klvanc_context_create(&ctx) < 0) {
 		fprintf(stderr, "Error initializing library context\n");
 		exit(1);
 	}
@@ -127,7 +128,7 @@ int scte104to35_main(int argc, char *argv[])
 
 	parse(ctx, &__0_vancentry[0], sizeof(__0_vancentry));
 
-	vanc_context_destroy(ctx);
+	klvanc_context_destroy(ctx);
 	printf("program complete.\n");
 	return 0;
 }


### PR DESCRIPTION
Adjust libklscte35 to deal with the mass-renaming of libklvanc
functions and structures.