### PR TITLE
Discard current splice info section if it is a splice insert request …

### DIFF
--- a/src/scte35-from104.c
+++ b/src/scte35-from104.c
@@ -76,6 +76,7 @@ static int scte35_generate_spliceinsert(struct klvanc_packet_scte_104_s *pkt, in
 	default:
 		fprintf(stderr, "Unknown Splice insert type %d\n",
 			op->sr_data.splice_insert_type);
+		(*outSpliceNum)--;
 		return -1;
 	}
 


### PR DESCRIPTION
…of type 0 (Reserved).

Current behavior is to leave remaining fields blank but still add the splice info section to the generated splices. A splice insert generated in this way looks identical to a splice cancel, which has the possibility to cause unintended behavior.