### PR TITLE
Fix for memory leak while transforming scte35 to scte104

### DIFF
--- a/src/scte35-to104.c
+++ b/src/scte35-to104.c
@@ -321,6 +321,8 @@ int scte35_create_scte104_message(struct scte35_splice_info_section_s *s, uint8_
 	/* Serialize the Multiple Operation Message out to a VANC array */
 	ret = klvanc_convert_SCTE_104_to_packetBytes(ctx, pkt, buf, byteCount);
 
+	klvanc_free_SCTE_104(pkt);
+
 	klvanc_context_destroy(ctx);
 
 	return ret;


### PR DESCRIPTION
After serializing the scte104 multiple operation message structure into
a provided VANC array pointer, where new memory is allocated for the
array pointer, the memory used earlier to allocate the structure is no
longer required. Hence, it needs to be freed before return.