### PR TITLE
Fix LDADD line for test tools built

### DIFF
--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -7,7 +7,7 @@ AM_CPPFLAGS = -DVERSION=\"$(VERSION)\" -DPROG="\"$(PACKAGE)\"" -D_FILE_OFFSET_BI
 	-DKL_USERSPACE
 AM_CFLAGS = -Wall -O3
 
-LDADD = ../src/libklscte35.la -lpthread -lz -ldl -lklvanc
+LDADD = ../src/libklscte35.la -lklvanc
 
 if DEBUG
 	CFLAGS += -g


### PR DESCRIPTION
The test tools had an hard-coded reference to zlib, which would prevent it from being built if the library was absent.  Because nothing uses zlib, just remove it (as well as a couple of unused deps).