### PR TITLE
Fix 104->35 preroll rollover & criteria.

### DIFF
--- a/src/scte35-from104.c
+++ b/src/scte35-from104.c
@@ -88,6 +88,7 @@ static int scte35_generate_spliceinsert(struct klvanc_packet_scte_104_s *pkt, in
 			/* Pre-roll time is in ms, PTS is in 90 KHz clock */
 			si->splice_insert.splice_time.pts_time = pts
 				+ op->sr_data.pre_roll_time * 90;
+			si->splice_insert.splice_time.pts_time &= 0x1fffffffful;
 		} else {
 			/* SCTE-104:2015 Sec 9.3.1.1 states "If zero (and Component
 			   Mode is not in use) the Injector should set the
@@ -141,11 +142,10 @@ static int scte35_generate_timesignal(struct klvanc_packet_scte_104_s *pkt, int 
 
 	splices[(*outSpliceNum)++] = si;
 
-	if (op->timesignal_data.pre_roll_time != 0) {
-		/* Pre-roll time is in ms, PTS is in 90 KHz clock */
-		si->time_signal.pts_time = pts + op->timesignal_data.pre_roll_time * 90;
-		si->time_signal.time_specified_flag = 1;
-	}
+	/* Pre-roll time is in ms, PTS is in 90 KHz clock */
+	si->time_signal.pts_time = pts + op->timesignal_data.pre_roll_time * 90;
+	si->time_signal.pts_time &= 0x1fffffffful;
+	si->time_signal.time_specified_flag = 1;
 
 	return 0;
 }


### PR DESCRIPTION
While splice_insert messages with zero preroll are supposed to be given a pts of zero, and the type set to immediate, time_signals do not have an equivalent concept, thus the pts should be provided regardless of the preroll specified in SCTE 104.

A guard against exceeding the maximum PTS value of 33 bits was also included for time_signal() and splice_insert() translations from SCTE 104. While serialization to SCTE 35 would truncate this value, adding the explicit truncation may reduce confusion for debugging / printing of the struct fields.