### PR TITLE
Fix misuse of klbitstream API

### DIFF
--- a/src/scte35.c
+++ b/src/scte35.c
@@ -762,7 +762,7 @@ int scte35_append_avail(struct scte35_splice_info_section_s *si, struct splice_d
 int scte35_parse_avail(struct splice_descriptor *desc, uint8_t *buf, unsigned int bufLength)
 {
 	struct klbs_context_s *bs = klbs_alloc();
-	klbs_write_set_buffer(bs, buf, bufLength);
+	klbs_read_set_buffer(bs, buf, bufLength);
 
 	desc->avail_data.provider_avail_id = klbs_read_bits(bs, 32);
 
@@ -803,7 +803,7 @@ int scte35_append_dtmf(struct scte35_splice_info_section_s *si, struct splice_de
 int scte35_parse_dtmf(struct splice_descriptor *desc, uint8_t *buf, unsigned int bufLength)
 {
 	struct klbs_context_s *bs = klbs_alloc();
-	klbs_write_set_buffer(bs, buf, bufLength);
+	klbs_read_set_buffer(bs, buf, bufLength);
 
 	desc->dtmf_data.preroll = klbs_read_bits(bs, 8);
 	desc->dtmf_data.dtmf_count = klbs_read_bits(bs, 3);
@@ -886,7 +886,7 @@ int scte35_parse_segmentation(struct splice_descriptor *desc, uint8_t *buf, unsi
 {
 	struct splice_descriptor_segmentation *seg = &desc->seg_data;
 	struct klbs_context_s *bs = klbs_alloc();
-	klbs_write_set_buffer(bs, buf, bufLength);
+	klbs_read_set_buffer(bs, buf, bufLength);
 
 	seg->event_id = klbs_read_bits(bs, 32);
 	seg->event_cancel_indicator = klbs_read_bits(bs, 1);
@@ -965,7 +965,7 @@ int scte35_append_time(struct scte35_splice_info_section_s *si, struct splice_de
 int scte35_parse_time(struct splice_descriptor *desc, uint8_t *buf, unsigned int bufLength)
 {
 	struct klbs_context_s *bs = klbs_alloc();
-	klbs_write_set_buffer(bs, buf, bufLength);
+	klbs_read_set_buffer(bs, buf, bufLength);
 
 	desc->time_data.TAI_seconds = klbs_read_bits(bs, 48);
 	desc->time_data.TAI_ns = klbs_read_bits(bs, 32);


### PR DESCRIPTION
We had a few cases where we were calling the set_write_buffer() call when we were actually doing reads.

This doesn't currently cause any problems, but is clearly incorrect.