### PR TITLE
Document gaps and assumptions vs the ANSI/SCTE 35:2019 specification

### DIFF
--- a/src/libklscte35/scte35.h
+++ b/src/libklscte35/scte35.h
@@ -24,6 +24,97 @@
  * @author	Steven Toth <stoth@kernellabs.com>
  * @copyright	Copyright (c) 2016-2017 Kernel Labs Inc. All Rights Reserved.
  * @brief	Pack, unpack DVB SCTE35 table sections. Helper functions to create common table types.
+ *
+ * SPEC COMPLIANCE SUMMARY (checked against ANSI/SCTE 35:2019, "Digital
+ * Program Insertion Cueing Message for Cable"; section numbers below refer
+ * to that edition unless noted). This is a deliberate subset of the spec,
+ * not a full implementation. Each GAP/ASSUMPTION callout below has a
+ * matching, more detailed comment at the point in the .c files where it
+ * actually applies -- this block is the index.
+ *
+ * GAPS (spec-defined behavior this library does not implement):
+ *
+ *  - splice_schedule() (Sec 9.7.2, splice_command_type 0x04) is not
+ *    implemented at all. Both scte35_splice_info_section_unpackFrom() and
+ *    scte35_splice_info_section_packTo() return -KLSCTE35_ERR_NOTSUPPORTED
+ *    for it. See src/scte35.c.
+ *
+ *  - Component splicing in splice_insert() (Sec 9.7.3, the
+ *    program_splice_flag == 0 case: per-component splice_time() loop) is
+ *    not implemented. See struct scte35_splice_insert_s below and
+ *    src/scte35.c (search "component_count").
+ *
+ *  - Encrypted messages are not supported, and packing vs. parsing handle
+ *    that asymmetrically: scte35_splice_info_section_packTo() rejects any
+ *    nonzero protocol_version, encrypted_packet or encryption_algorithm
+ *    outright, but scte35_splice_info_section_unpackFrom() does not -- it
+ *    silently parses the command/descriptor loop as if the section were
+ *    unencrypted, which for a genuinely encrypted section means
+ *    misinterpreting ciphertext as a real command. alignment_stuffing()
+ *    and E_CRC_32 (Sec 9.6, present only when encrypted_packet == 1) are
+ *    never produced or consumed either way; e_crc_32 in struct
+ *    scte35_splice_info_section_s is always 0. Callers that need to
+ *    detect an encrypted section on the parse path must check
+ *    si->encrypted_packet themselves. See src/scte35.c,
+ *    scte35_splice_info_section_packTo()/_unpackFrom().
+ *
+ *  - segmentation_descriptor() sub_segment_num/sub_segments_expected
+ *    (Sec 10.3.3, present when segmentation_type_id is a Provider/
+ *    Distributor Placement Opportunity Start, 0x34 or 0x36) are declared
+ *    in struct splice_descriptor_segmentation below but are never read or
+ *    written on the wire. See src/scte35.c,
+ *    scte35_append_segmentation()/scte35_parse_segmentation().
+ *
+ *  - segmentation_upid() (Sec 10.3.3.1) is stored and round-tripped as an
+ *    opaque byte blob for every upid_type. Type-specific structure is not
+ *    decoded: fixed-length UPID types (e.g. UMID, UUID) aren't validated
+ *    against their mandated length, and upid_type 0x0D (MID, a nested
+ *    list of sub-UPIDs) is not expanded into its component UPIDs -- the
+ *    concatenated sub-UPID bytes are exposed as-is. See
+ *    struct splice_descriptor_segmentation below.
+ *
+ *  - segmentation_event_id_compliance_indicator and
+ *    splice_event_id_compliance_indicator, added in later SCTE-35
+ *    revisions by repurposing one bit of the "reserved" field that
+ *    follows event_cancel_indicator in segmentation_descriptor() and
+ *    splice_insert(), are not recognized -- this library always treats
+ *    that entire field as reserved and discards it.
+ *
+ * ASSUMPTIONS (choices made where the spec is ambiguous, silent, or where
+ * this library deliberately narrows/deviates from recommended behavior):
+ *
+ *  - protocol_version (Sec 9.6): the spec's intent for forward
+ *    compatibility is that a decoder encountering an unknown protocol
+ *    version should ignore the section rather than treat it as an error.
+ *    This library instead hard-rejects any splice_info_section() with
+ *    protocol_version != 0 when *packing* one -- but, inconsistently,
+ *    _unpackFrom() doesn't check it at all on the parse side and will
+ *    happily attempt to decode a section with a nonzero protocol_version
+ *    as if it were 0 (see the encryption bullet above for the related
+ *    parse-side gap).
+ *
+ *  - segmentation_descriptor() delivery restriction flags (Sec 10.3.3):
+ *    when delivery_not_restricted_flag == 1, web_delivery_allowed_flag,
+ *    no_regional_blackout_flag, archive_allowed_flag and
+ *    device_restrictions are not present on the wire (just reserved
+ *    bits). This library fabricates values for them on parse
+ *    (all "allowed" / device_restrictions = 0x03 "None") so callers
+ *    always see a fully-populated struct; that's an interpretation of
+ *    "not restricted", not a value the bitstream actually carries.
+ *
+ *  - Unrecognized splice_descriptor_tag values (with or without the CUEI
+ *    identifier) are treated as opaque/private and passed through as raw
+ *    bytes via struct splice_descriptor_arbitrary, rather than rejected.
+ *    This matches the spec's intended extensibility model for
+ *    descriptors, so it's listed here as a documented assumption rather
+ *    than a gap.
+ *
+ *  - SCTE35_MAX_DESCRIPTORS (64) and the various fixed-size byte arrays
+ *    below (e.g. upid[255], private_byte[255]) are practical caps chosen
+ *    to match the maximum a single 8-bit length field can express (255)
+ *    or a generous real-world descriptor count -- they are not values
+ *    mandated by the spec, which places no fixed upper bound on
+ *    descriptor_loop_count itself.
  */
 
 #ifndef SCTE35_H
@@ -45,6 +136,10 @@ extern "C" {
 #define KLSCTE35_ERR_NOTSUPPORTED 3
 
 #define SCTE35_COMMAND_TYPE__SPLICE_NULL	0x00
+/* GAP: recognized as a valid command_type (e.g. by scte35_splice_info_section_
+   alloc()) but splice_schedule() itself (Sec 9.7.2) is not implemented --
+   scte35_splice_info_section_packTo()/_unpackFrom() both return
+   -KLSCTE35_ERR_NOTSUPPORTED for it in src/scte35.c. */
 #define SCTE35_COMMAND_TYPE__SPLICE_SCHEDULE	0x04
 #define SCTE35_COMMAND_TYPE__SPLICE_INSERT	0x05
 #define SCTE35_COMMAND_TYPE__TIME_SIGNAL	0x06
@@ -97,9 +192,18 @@ struct splice_descriptor_segmentation
 {
 	uint32_t event_id;
 	uint8_t event_cancel_indicator;
+	/* GAP: newer SCTE-35 revisions add segmentation_event_id_compliance_indicator
+	   as one bit of the 7 reserved bits that follow event_cancel_indicator on the
+	   wire. Not represented here -- src/scte35.c reads/writes all 7 bits as pure
+	   reserved (see scte35_parse_segmentation()/scte35_append_segmentation()). */
 	uint8_t program_segmentation_flag;
 	uint8_t segmentation_duration_flag;
 	uint8_t delivery_not_restricted_flag;
+	/* ASSUMPTION: when delivery_not_restricted_flag == 1, the next 3 flags and
+	   device_restrictions are not actually present on the wire (just reserved
+	   bits per Sec 10.3.3). src/scte35.c's parser fabricates "fully allowed" /
+	   device_restrictions = 0x03 in that case so this struct is always fully
+	   populated -- that's an interpretation, not a transmitted value. */
 	uint8_t web_delivery_allowed_flag;
 	uint8_t no_regional_blackout_flag;
 	uint8_t archive_allowed_flag;
@@ -109,10 +213,22 @@ struct splice_descriptor_segmentation
 	uint64_t segmentation_duration;
 	uint8_t upid_type;
 	uint8_t upid_length;
+	/* GAP: segmentation_upid() (Sec 10.3.3.1) is stored here as an opaque byte
+	   blob regardless of upid_type. Fixed-length UPID types (e.g. upid_type
+	   0x04 UMID = 32 bytes, 0x10 UUID = 16 bytes) are not validated against
+	   their mandated length, and upid_type 0x0D (MID -- a nested list of
+	   sub-UPIDs, each with its own upid_type/upid_length/upid) is not expanded;
+	   its concatenated sub-UPID bytes are exposed here exactly as received. */
 	uint8_t upid[255];
 	uint8_t type_id;
 	uint8_t segment_num;
 	uint8_t segments_expected;
+	/* GAP: these two fields exist in the struct but src/scte35.c never reads or
+	   writes them on the wire, even when type_id is 0x34 or 0x36 (Provider/
+	   Distributor Placement Opportunity Start), the case the spec defines them
+	   for (Sec 10.3.3). They are always 0 after a parse, and packing never
+	   emits them regardless of what a caller sets here. See "FIXME: Sub
+	   segment num" in scte35_parse_segmentation()/scte35_append_segmentation(). */
 	uint8_t sub_segment_num;
 	uint8_t sub_segments_expected;
 };
@@ -178,15 +294,27 @@ struct scte35_splice_insert_s
 {
 	uint32_t splice_event_id;
 	uint8_t  splice_event_cancel_indicator;
+	/* GAP: as with segmentation_descriptor(), later SCTE-35 revisions add a
+	   splice_event_id_compliance_indicator bit to the reserved field that
+	   follows splice_event_cancel_indicator. Not represented -- treated as
+	   pure reserved on both parse and pack. */
 	uint8_t  out_of_network_indicator;
 	uint8_t  program_splice_flag;
 	uint8_t  duration_flag;
 	uint8_t  splice_immediate_flag;
 	struct   scte35_splice_time_s splice_time;
 
-	/* We don't support program_splice_flag == 0 */
-
-	/* We don't support component counts */
+	/* GAP: Sec 9.7.3 defines component splicing when program_splice_flag == 0:
+	   a component_count(8) followed by that many {component_tag(8), splice_time()}
+	   entries, letting a splice apply to specific elementary streams instead of
+	   the whole program. This library does not implement it -- when
+	   program_splice_flag == 0, scte35_splice_info_section_unpackFrom() reads
+	   and discards a single fixed 8-bit field instead of the real
+	   component_count + per-component loop, and
+	   scte35_splice_info_section_packTo() always writes that field as 0. The
+	   component_count/components[] fields below are consequently never
+	   populated by this library; program_splice_flag == 0 input round-trips
+	   incorrectly. See src/scte35.c (search "component_count"). */
 	uint8_t  component_count;
 	struct   scte35_splice_component_s components[256];
 
@@ -214,7 +342,17 @@ struct scte35_splice_info_section_s
 	uint8_t  section_syntax_indicator;
 	uint8_t  private_indicator;
 	uint16_t section_length;
+	/* ASSUMPTION: Sec 9.6 intends protocol_version as a forward-compatibility
+	   field -- a decoder seeing a value it doesn't recognize should ignore the
+	   section, not reject the stream outright. This library instead hard-fails
+	   (-KLSCTE35_ERR_INVAL) any section where protocol_version != 0, on both
+	   parse and pack. */
 	uint8_t  protocol_version;
+	/* GAP: encrypted_packet/encryption_algorithm are read/written, but a
+	   nonzero value on either is always rejected -- encrypted messages
+	   (Sec 9.6, including alignment_stuffing() and E_CRC_32) are not
+	   supported at all. See scte35_splice_info_section_packTo()/
+	   _unpackFrom() in src/scte35.c. */
 	uint8_t  encrypted_packet;
 	uint8_t  encryption_algorithm;
 	uint64_t pts_adjustment;
@@ -222,6 +360,11 @@ struct scte35_splice_info_section_s
 	uint16_t tier;
 	uint16_t splice_command_length;
 	uint8_t  splice_command_type;
+	/* GAP: no member here for splice_schedule() (Sec 9.7.2,
+	   splice_command_type 0x04) -- it isn't implemented, see
+	   SCTE35_COMMAND_TYPE__SPLICE_SCHEDULE below. bandwidth_reservation()
+	   correctly has no member since Sec 9.7.5 defines it as an empty
+	   structure. */
 	union {
 		struct scte35_splice_null_s splice_null;
 		struct scte35_splice_insert_s splice_insert;
@@ -236,6 +379,8 @@ struct scte35_splice_info_section_s
 	uint16_t descriptor_loop_length;
 	uint8_t  *splice_descriptor;
 
+	/* GAP: always 0. E_CRC_32 (Sec 9.6) only exists in encrypted sections,
+	   which this library doesn't support -- see encrypted_packet above. */
 	uint32_t e_crc_32;
 	uint32_t crc_32;
 	uint32_t crc_32_is_valid;

--- a/src/scte35-from104.c
+++ b/src/scte35-from104.c
@@ -342,7 +342,17 @@ static int scte35_append_104_segmentation(struct klvanc_packet_scte_104_s *pkt, 
 	sd->identifier = 0x43554549; /* CUEI */
 	sd->seg_data.event_id = seg->event_id;
 	sd->seg_data.event_cancel_indicator = seg->event_cancel_indicator;
-	sd->seg_data.program_segmentation_flag = 1; /* FIXME: Component mode */
+	/* GAP: struct klvanc_segmentation_descriptor_request_data (the SCTE-104
+	   MO_INSERT_SEGMENTATION_REQUEST_DATA operation this converts from) has
+	   no component_count/component fields at all, so there's no SCTE-104
+	   input to convert -- this always emits program-level segmentation
+	   (program_segmentation_flag = 1). Note this is a limitation of the
+	   SCTE-104 side specifically: scte35_append_segmentation() in
+	   src/scte35.c *does* support writing real component-mode segmentation
+	   descriptors when program_segmentation_flag == 0 and
+	   component_count/components[] are populated directly through the
+	   public API; that path just isn't reachable from SCTE-104 conversion. */
+	sd->seg_data.program_segmentation_flag = 1;
 	sd->seg_data.delivery_not_restricted_flag = seg->delivery_not_restricted_flag;
 	sd->seg_data.web_delivery_allowed_flag = seg->web_delivery_allowed_flag;
 	sd->seg_data.no_regional_blackout_flag = seg->no_regional_blackout_flag;
@@ -359,6 +369,13 @@ static int scte35_append_104_segmentation(struct klvanc_packet_scte_104_s *pkt, 
 	sd->seg_data.type_id = seg->type_id;
 	sd->seg_data.segment_num = seg->segment_num;
 	sd->seg_data.segments_expected = seg->segments_expected;
+	/* GAP: struct klvanc_segmentation_descriptor_request_data has no
+	   sub_segment_num/sub_segments_expected fields to convert from, so
+	   these are always 0 here regardless of type_id -- moot today since
+	   scte35_append_segmentation() in src/scte35.c doesn't write these
+	   fields at all yet (see the GAP comment there), but would still be
+	   wrong input for a Provider/Distributor Placement Opportunity Start
+	   (type_id 0x34/0x36) once that's fixed. */
 	sd->seg_data.sub_segment_num = 0;
 	sd->seg_data.sub_segments_expected = 0;
 

--- a/src/scte35-tojson.c
+++ b/src/scte35-tojson.c
@@ -59,7 +59,12 @@ static int json_generate_splice_insert(const struct scte35_splice_insert_s *si, 
 			}
 		}
 		if (si->program_splice_flag == 0) {
-			/* Component mode, not supported */
+			/* GAP: consistent with the rest of this library --
+			   splice_insert() component mode (Sec 9.7.3) isn't parsed in
+			   the first place (see the GAP comment in
+			   scte35_splice_info_section_unpackFrom(), src/scte35.c), so
+			   there's no per-component data available to emit here even in
+			   principle. */
 		}
 		if (si->duration_flag == 1) {
 			/* break_duration */
@@ -260,7 +265,12 @@ static int json_append_segmentation(struct splice_descriptor *sd, json_object *o
 					       json_object_new_int64(sd->seg_data.device_restrictions));
 		}
 		if (sd->seg_data.program_segmentation_flag == 0) {
-			/* Component mode not supported */
+			/* GAP: unlike the core wire codec (scte35_append_segmentation()/
+			   scte35_parse_segmentation() in src/scte35.c, which do support
+			   component-mode segmentation), the JSON serializer omits
+			   component_count/components[] entirely here -- a component-mode
+			   segmentation_descriptor() parsed from the wire loses that data
+			   when converted to JSON. */
 		}
 		if (sd->seg_data.segmentation_duration_flag == 1) {
 			json_object_object_add(desc, "segmentation_duration",
@@ -268,7 +278,12 @@ static int json_append_segmentation(struct splice_descriptor *sd, json_object *o
 		}
 		json_object_object_add(desc, "segmentation_upid_type",
 				       json_object_new_int64(sd->seg_data.upid_type));
-		/* FIXME: segmentation upid bytes */
+		/* GAP: segmentation_upid_length and the actual upid bytes (Sec
+		   10.3.3.1) are never added to the JSON output -- only upid_type is
+		   present. Same underlying data gap as noted in
+		   scte35_parse_segmentation() (src/scte35.c): the raw bytes are
+		   available in sd->seg_data.upid[]/upid_length, just not emitted
+		   here. */
 
 		json_object_object_add(desc, "segmentation_type_id",
 				       json_object_new_int64(sd->seg_data.type_id));

--- a/src/scte35.c
+++ b/src/scte35.c
@@ -101,6 +101,16 @@ static const char *scte35_seg_device_restrictions(uint8_t val) {
 
 static const char *scte35_seg_upid_type(uint8_t upid_type) {
 	/* SCTE-35:2019 Table 21 */
+	/* GAP: this table only covers upid_type 0x00-0x09. Every later-edition
+	   type -- at least 0x0A EIDR, 0x0B ATSC Content Identifier, 0x0C MPU(),
+	   0x0D MID() (nested sub-UPID list), 0x0E ADS Information, 0x0F URI,
+	   0x10 UUID (SMPTE 2092-1), and whatever a given edition adds beyond
+	   that -- falls through to "Reserved" here even though it's a defined,
+	   named type in the spec. This is purely a human-readable-label gap:
+	   the underlying upid bytes are still stored/round-tripped correctly
+	   regardless of type (see the GAP comment on segmentation_upid_type in
+	   scte35_parse_segmentation()); only this descriptive string is wrong
+	   for those types. */
 	switch(upid_type) {
 	case 0x00: return "Not Used";
 	case 0x01: return "User Defined (Deprecated)";
@@ -561,6 +571,19 @@ ssize_t scte35_splice_info_section_unpackFrom(struct scte35_splice_info_section_
 
 	si->section_length = klbs_read_bits(bs, 12);
 
+	/* GAP/ASSUMPTION: unlike scte35_splice_info_section_packTo() (which
+	   rejects any nonzero protocol_version, encrypted_packet or
+	   encryption_algorithm), this parser does not reject them here -- it
+	   reads and stores whatever values are present and then keeps parsing
+	   the command/descriptor loop as if the section were unencrypted,
+	   protocol_version 0. For a genuinely encrypted section (Sec 9.6) this
+	   means the "splice_command" bytes are actually ciphertext that gets
+	   misinterpreted as a real command, alignment_stuffing()/E_CRC_32
+	   (present before the final CRC_32 in that case) are never skipped, so
+	   the trailing crc_32 field itself is read from the wrong offset. The
+	   net effect is usually (not guaranteed) crc_32_is_valid == 0 and a
+	   struct full of garbage rather than a clean rejection -- callers must
+	   check si->encrypted_packet themselves if they need to detect this. */
 	si->protocol_version = klbs_read_bits(bs, 8);
 	si->encrypted_packet = klbs_read_bits(bs, 1);
 	si->encryption_algorithm = klbs_read_bits(bs, 6);
@@ -577,6 +600,13 @@ ssize_t scte35_splice_info_section_unpackFrom(struct scte35_splice_info_section_
 		/* Nothing to do */
 	} else
 	if (si->splice_command_type == SCTE35_COMMAND_TYPE__SPLICE_SCHEDULE) {
+		/* GAP (SCTE-35 Sec 9.7.2): splice_schedule() is a real, spec-defined
+		   command -- a list of splice_event()s scheduled for future UTC
+		   splice_time()s -- not merely a reserved/unused command_type. This
+		   library has no struct to hold it and cannot parse it at all;
+		   any section using it is rejected outright rather than degraded
+		   gracefully (e.g. by skipping the command and still parsing
+		   descriptors). */
 		klbs_free(bs);
 		return -KLSCTE35_ERR_NOTSUPPORTED;
 	} else
@@ -605,7 +635,17 @@ ssize_t scte35_splice_info_section_unpackFrom(struct scte35_splice_info_section_
 					klbs_read_bits(bs, 7); /* Reserved */
 			}
 			if (i->program_splice_flag == 0) {
-				/* TODO: We don't support component counts, write fixed values */
+				/* GAP (SCTE-35 Sec 9.7.3): program_splice_flag == 0 means this
+				   is a per-component splice -- the wire format here is
+				   component_count(8) followed by that many
+				   {component_tag(8), splice_time()} entries (splice_time()
+				   only present if splice_immediate_flag == 0), not a single
+				   fixed byte. This library reads and discards one byte and
+				   stops; any component_tag/splice_time data that follows is
+				   left unparsed, and si->splice_insert.component_count /
+				   .components[] (see scte35.h) are never populated. A
+				   program_splice_flag == 0 splice_insert() does not
+				   round-trip correctly through this library. */
 				klbs_read_bits(bs, 8);
 			}
 			if (i->duration_flag == 1) {
@@ -677,8 +717,10 @@ ssize_t scte35_splice_info_section_unpackFrom(struct scte35_splice_info_section_
 					 si->descriptor_loop_length);
 	}
 
-	/* We don't support encryption so we dont need alignment stuffing */
-	/* We don't support encrypted_packets so we dont need e_crc_32 */
+	/* GAP (SCTE-35 Sec 9.6): alignment_stuffing() and E_CRC_32, which the spec
+	   requires here when encrypted_packet == 1, are never read -- see the GAP
+	   comment on the protocol_version/encrypted_packet reads above for how
+	   that silently misaligns parsing of an actually-encrypted section. */
 	si->e_crc_32 = 0;
 
 	/* Checksum */
@@ -874,14 +916,18 @@ int scte35_append_segmentation(struct scte35_splice_info_section_s *si, struct s
 			klbs_write_bits(bs, 0x1f, 5); /* Reserved */
 		}
 		if (seg->program_segmentation_flag == 0) {
+			/* Component mode (Sec 10.3.3) IS implemented here, unlike
+			   splice_insert()'s program_splice_flag == 0 case above -- this
+			   writes the real component_count + per-component
+			   {component_tag, pts_offset} loop from seg->component_count/
+			   .components[]. (An earlier version of this comment claimed
+			   otherwise; that was stale/incorrect.) */
 			klbs_write_bits(bs, seg->component_count, 8);
 			for (int i = 0; i < seg->component_count; i++) {
 				klbs_write_bits(bs, seg->components[i].component_tag, 8);
 				klbs_write_bits(bs, 0x7f, 7); /* Reserved */
 				klbs_write_bits(bs, seg->components[i].pts_offset, 33);
 			}
-
-			/* FIXME: Component mode not currently supported */
 		}
 		if (seg->segmentation_duration_flag) {
 			klbs_write_bits(bs, seg->segmentation_duration, 40);
@@ -895,7 +941,12 @@ int scte35_append_segmentation(struct scte35_splice_info_section_s *si, struct s
 		klbs_write_bits(bs, seg->segment_num, 8);
 		klbs_write_bits(bs, seg->segments_expected, 8);
 		if (seg->type_id == 0x34 || seg->type_id == 0x36) {
-			/* FIXME: Sub segment num */
+			/* GAP (SCTE-35 Sec 10.3.3): for Provider/Distributor Placement
+			   Opportunity Start, the spec requires sub_segment_num(8) and
+			   sub_segments_expected(8) here. Neither is written -- whatever
+			   a caller set in seg->sub_segment_num/.sub_segments_expected
+			   (see scte35.h) is silently dropped, producing a
+			   non-compliant (2 bytes short) descriptor for this type_id. */
 		}
 	}
 	klbs_write_buffer_complete(bs);
@@ -938,6 +989,12 @@ int scte35_parse_segmentation(struct splice_descriptor *desc, uint8_t *buf, unsi
 			seg->archive_allowed_flag = klbs_read_bits(bs, 1);
 			seg->device_restrictions =  klbs_read_bits(bs, 2);
 		} else {
+			/* ASSUMPTION: these 3 flags + device_restrictions aren't on the
+			   wire when delivery_not_restricted_flag == 1 (just the 5
+			   reserved bits below) -- fabricating "fully allowed" values
+			   here is this library's interpretation of "not restricted",
+			   not a transmitted value. See scte35.h,
+			   struct splice_descriptor_segmentation. */
 			klbs_read_bits(bs, 5); /* Reserved */
 			seg->web_delivery_allowed_flag = 1;
 			seg->no_regional_blackout_flag = 1;
@@ -957,6 +1014,11 @@ int scte35_parse_segmentation(struct splice_descriptor *desc, uint8_t *buf, unsi
 		}
 		seg->upid_type = klbs_read_bits(bs, 8);
 		seg->upid_length = klbs_read_bits(bs, 8);
+		/* GAP (SCTE-35 Sec 10.3.3.1): segmentation_upid() is stored as an
+		   opaque blob here regardless of upid_type -- no length validation
+		   against type-specific fixed sizes, and upid_type 0x0D (MID, a
+		   nested list of sub-UPIDs) is not expanded. See scte35.h,
+		   struct splice_descriptor_segmentation, field "upid". */
 		for (int i = 0; i < seg->upid_length; i++) {
 			seg->upid[i] = klbs_read_bits(bs, 8);
 		}
@@ -964,7 +1026,12 @@ int scte35_parse_segmentation(struct splice_descriptor *desc, uint8_t *buf, unsi
 		seg->segment_num = klbs_read_bits(bs, 8);
 		seg->segments_expected = klbs_read_bits(bs, 8);
 		if (seg->type_id == 0x34 || seg->type_id == 0x36) {
-			/* FIXME: Sub segment num */
+			/* GAP (SCTE-35 Sec 10.3.3): sub_segment_num(8) and
+			   sub_segments_expected(8) are mandatory here for Provider/
+			   Distributor Placement Opportunity Start but are never read --
+			   seg->sub_segment_num/.sub_segments_expected are left at
+			   whatever they were before this call (0 for a freshly
+			   allocated/calloc'd struct) rather than the wire values. */
 		}
 	}
 
@@ -1125,7 +1192,9 @@ int scte35_splice_info_section_packTo(struct scte35_splice_info_section_s *si, u
 		/* Nothing to do */
 	} else
 	if (si->splice_command_type == SCTE35_COMMAND_TYPE__SPLICE_SCHEDULE) {
-		/* TODO: Not supported */
+		/* GAP (SCTE-35 Sec 9.7.2): splice_schedule() is not implemented --
+		   see the matching comment in scte35_splice_info_section_unpackFrom()
+		   above. */
 		klbs_free(bs);
 		return -KLSCTE35_ERR_NOTSUPPORTED;
 	} else
@@ -1152,7 +1221,12 @@ int scte35_splice_info_section_packTo(struct scte35_splice_info_section_s *si, u
 					klbs_write_bits(bs, 0xff, 7); /* Reserved */
 			}
 			if (i->program_splice_flag == 0) {
-				/* TODO: We don't support component counts, write fixed values */
+				/* GAP (SCTE-35 Sec 9.7.3): component splicing isn't
+				   supported -- see the matching comment in
+				   scte35_splice_info_section_unpackFrom() above. Whatever a
+				   caller set in si->splice_insert.component_count/
+				   .components[] is ignored; a fixed 0 (component_count) is
+				   always written instead. */
 				klbs_write_bits(bs, 0, 8);
 			}
 			if (i->duration_flag == 1) {
@@ -1242,8 +1316,11 @@ int scte35_splice_info_section_packTo(struct scte35_splice_info_section_s *si, u
 		klbs_write_bits(bs, si->splice_descriptor[i], 8);
 	}
 
-	/* We don't support encryption so we dont need alignment stuffing */
-	/* We don't support encrypted_packets so we dont need e_crc_32 */
+	/* GAP (SCTE-35 Sec 9.6): alignment_stuffing() and E_CRC_32 are never
+	   written -- moot here since encrypted_packet != 0 was already rejected
+	   above, but see the matching comment in
+	   scte35_splice_info_section_unpackFrom() for the parse-side gap this
+	   creates (that function doesn't reject it). */
 	si->e_crc_32 = 0;
 
 	si->section_length = klbs_get_byte_count(bs)


### PR DESCRIPTION
Reviews the implementation against the spec section by section and adds GAP/ASSUMPTION comments at each point of divergence, both as a new top-of-file compliance summary in src/libklscte35/scte35.h and inline at the exact code that implements (or doesn't implement) each behavior. Comment-only change; full suite still 212 passed, 0 failed.

GAPS (spec-defined behavior not implemented):

- splice_schedule() (Sec 9.7.2) isn't implemented at all -- both pack and unpack return NOTSUPPORTED.
- Component splicing in splice_insert() (Sec 9.7.3, program_splice_flag == 0) isn't implemented -- a single placeholder byte is read/written instead of the real component_count + per-component splice_time() loop.
- Encrypted messages aren't supported, and pack vs. parse handle that asymmetrically: packTo() rejects any nonzero protocol_version/encrypted_packet/encryption_algorithm outright, but unpackFrom() doesn't check them at all and will silently attempt to parse an encrypted section's ciphertext as if it were a real command. alignment_stuffing()/E_CRC_32 (Sec 9.6) are never handled either way.
- segmentation_descriptor() sub_segment_num/sub_segments_expected (Sec 10.3.3, Placement Opportunity Start, type_id 0x34/0x36) exist in the struct but are never read or written on the wire, in either the core codec or the SCTE-104 conversion layer.
- segmentation_upid() (Sec 10.3.3.1) is stored as an opaque blob for every upid_type -- no length validation, and MID (0x0D, a nested sub-UPID list) isn't expanded. The upid_type label table also only covers 0x00-0x09 (cosmetic only; bytes still round-trip).
- segmentation_event_id_compliance_indicator / splice_event_id_compliance_indicator, added to reserved fields in later spec revisions, aren't recognized.

Also corrects a stale/incorrect comment in scte35_append_segmentation() that claimed component mode wasn't supported directly above code that actually implements it correctly -- the real gap is one layer up (SCTE-104 conversion always hardcodes program_segmentation_flag = 1, and JSON output drops component data even when present in the struct).

ASSUMPTIONS (interpretive choices where the spec is silent, or where behavior deliberately deviates from its recommendation): protocol_version handling (spec says ignore unknown versions; this rejects on pack, doesn't check on unpack), fabricated "fully allowed" delivery-restriction values when delivery_not_restricted_flag == 1, treating unrecognized descriptor tags as opaque passthrough (confirmed spec-compliant, documented as intentional rather than a gap), and the practical (not spec-mandated) fixed-size caps like SCTE35_MAX_DESCRIPTORS.